### PR TITLE
Rename team logo items to home/away item fields

### DIFF
--- a/src/config/DBConfig.cs
+++ b/src/config/DBConfig.cs
@@ -290,17 +290,20 @@ namespace VLeague
             }
         }
         //Update team info when setup homeTeam or awayTeam
-        public static void updateTeamInfo(string teamCode, string longName ,
-            string shortName , string coach , string logo, string gk_color , string player_color) 
+        public static void updateTeamInfo(string teamCode, string longName,
+            string shortName, string coach, string logo, string homeItem, string awayItem, string goalItem, string gk_color, string player_color)
         {
             try
             {
-                oledbCommand = new OleDbCommand("Update TEAM_ID set TenDai = @tendai, TenNgan = @tenngan, HLV = @hlv, Logo = @logo where MaDoi = @madoi", oledbConnection);
+                oledbCommand = new OleDbCommand("Update TEAM_ID set TenDai = @tendai, TenNgan = @tenngan, HLV = @hlv, Logo = @logo, HOME_ITEM = @homeItem, AWAY_ITEM = @awayItem, GOAL_ITEM = @goalItem where MaDoi = @madoi", oledbConnection);
                 oledbCommand.CommandType = CommandType.Text;
                 oledbCommand.Parameters.Add("@tendai", OleDbType.VarWChar).Value = longName;
                 oledbCommand.Parameters.Add("@tenngan", OleDbType.VarWChar).Value = shortName;
                 oledbCommand.Parameters.Add("@hlv", OleDbType.VarWChar).Value = coach;
                 oledbCommand.Parameters.Add("@logo", OleDbType.VarWChar).Value = logo;
+                oledbCommand.Parameters.Add("@homeItem", OleDbType.VarWChar).Value = (object)homeItem ?? DBNull.Value;
+                oledbCommand.Parameters.Add("@awayItem", OleDbType.VarWChar).Value = (object)awayItem ?? DBNull.Value;
+                oledbCommand.Parameters.Add("@goalItem", OleDbType.VarWChar).Value = (object)goalItem ?? DBNull.Value;
 
                 oledbCommand.Parameters.Add("@madoi", OleDbType.VarWChar).Value = teamCode;
                 oledbCommand.ExecuteNonQuery();

--- a/src/menu/FrmDataImport.cs
+++ b/src/menu/FrmDataImport.cs
@@ -14,9 +14,9 @@ namespace VLeague.src.menu
 {
     public partial class FrmDataImport : Form
     {
-        public static string homeCode, homeTactical, homeTenDai, homeTenNgan, homeHLV, homeLogo, homeLogoIn, homeLogoOut;
+        public static string homeCode, homeTactical, homeTenDai, homeTenNgan, homeHLV, homeLogo, homeHomeItem, homeAwayItem, homeGoalItem;
 
-        public static string awayCode, awayTactical, awayTenDai, awayTenNgan, awayHLV, awayLogo, awayLogoIn, awayLogoOut;
+        public static string awayCode, awayTactical, awayTenDai, awayTenNgan, awayHLV, awayLogo, awayHomeItem, awayAwayItem, awayGoalItem;
 
         private ColorDialog colorDialog;
 
@@ -94,8 +94,9 @@ namespace VLeague.src.menu
             homeLogo = DBConfig.doGetStringTeamID(homeCode, "Logo");
             picHomeLogo.Image = Image.FromFile(homeLogo);
 
-            homeLogoIn = DBConfig.doGetStringTeamID(homeCode, "LOGOIN");
-            homeLogoOut = DBConfig.doGetStringTeamID(homeCode, "LOGOOUT");
+            homeHomeItem = DBConfig.doGetStringTeamID(homeCode, "HOME_ITEM");
+            homeAwayItem = DBConfig.doGetStringTeamID(homeCode, "AWAY_ITEM");
+            homeGoalItem = DBConfig.doGetStringTeamID(homeCode, "GOAL_ITEM");
 
         }
         private void LoadTeamInfoAway()
@@ -109,10 +110,10 @@ namespace VLeague.src.menu
             awayLogo = DBConfig.doGetStringTeamID(awayCode, "Logo");
             picAwayLogo.Image = Image.FromFile(awayLogo);
 
-            awayLogoIn = DBConfig.doGetStringTeamID(awayCode, "LOGOIN");
+            awayHomeItem = DBConfig.doGetStringTeamID(awayCode, "HOME_ITEM");
 
-            awayLogoOut = DBConfig.doGetStringTeamID(awayCode, "LOGOOUT");
-            awayLogoOut = DBConfig.doGetStringTeamID(awayCode, "LOGOOUT");
+            awayAwayItem = DBConfig.doGetStringTeamID(awayCode, "AWAY_ITEM");
+            awayGoalItem = DBConfig.doGetStringTeamID(awayCode, "GOAL_ITEM");
         }
 
         private void InitializeComboBoxes()
@@ -160,11 +161,14 @@ namespace VLeague.src.menu
                 string shortName = row.Cells["TenNgan"].Value?.ToString();
                 string coach = row.Cells["HLV"].Value?.ToString();
                 string logo = row.Cells["Logo"].Value?.ToString();
+                string homeItem = row.Cells["HOME_ITEM"].Value?.ToString();
+                string awayItem = row.Cells["AWAY_ITEM"].Value?.ToString();
+                string goalItem = row.Cells["GOAL_ITEM"].Value?.ToString();
                 string gk_color = row.Cells["Gk_Color"].Value?.ToString();
                 string player_color = row.Cells["Player_Color"].Value?.ToString();
 
                 // Gọi hàm cập nhật cơ sở dữ liệu
-                DBConfig.updateTeamInfo(teamCode, longName, shortName, coach, logo, gk_color, player_color);
+                DBConfig.updateTeamInfo(teamCode, longName, shortName, coach, logo, homeItem, awayItem, goalItem, gk_color, player_color);
             }
 
         }
@@ -673,8 +677,8 @@ namespace VLeague.src.menu
             LoadPlayersAway();
             TeamInfor.UpdateData(homeCode, homeTactical, homeTenDai, homeTenNgan, homeHLV, homeLogo,
             awayCode, awayTactical, awayTenDai, awayTenNgan, awayHLV, awayLogo,
-         Player_HomeColor.BackColor, Player_AwayColor.BackColor, homeLogoIn, homeLogoOut, awayLogoIn, awayLogoOut,
-         GK_HomeColor.BackColor, GK_AwayColor.BackColor);
+         Player_HomeColor.BackColor, Player_AwayColor.BackColor, homeHomeItem, homeAwayItem, awayHomeItem, awayAwayItem,
+         homeGoalItem, awayGoalItem, GK_HomeColor.BackColor, GK_AwayColor.BackColor);
             Static.AwayNameGoals = new string[10, 3];
             Static.HomeNameGoals = new string[10, 3];
 

--- a/src/menu/FrmInMatchClock.cs
+++ b/src/menu/FrmInMatchClock.cs
@@ -540,11 +540,11 @@ namespace VLeague.src.menu
                 case 1:
                     if (!string.IsNullOrEmpty(inforHomePlayer.Text))
                     {
-                        FrmKarismaMenu.FrmSetting.loadTitleScene(cbbHomePlayer.Text, inforHomePlayer.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+                        FrmKarismaMenu.FrmSetting.loadTitleScene(cbbHomePlayer.Text, inforHomePlayer.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
                     }
                     else
                     {
-                        FrmKarismaMenu.FrmSetting.loadTitleScene(cbbHomePlayer.Text, TeamInfor.homeTenDai, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+                        FrmKarismaMenu.FrmSetting.loadTitleScene(cbbHomePlayer.Text, TeamInfor.homeTenDai, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
                     }
                     break;
             }
@@ -577,11 +577,11 @@ namespace VLeague.src.menu
                 case 1:
                     if (!string.IsNullOrEmpty(inforAwayPlayer.Text))
                     {
-                        FrmKarismaMenu.FrmSetting.loadTitleScene(cbbAwayPlayer.Text, inforAwayPlayer.Text, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut);
+                        FrmKarismaMenu.FrmSetting.loadTitleScene(cbbAwayPlayer.Text, inforAwayPlayer.Text, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem);
                     }
                     else
                     {
-                        FrmKarismaMenu.FrmSetting.loadTitleScene(cbbAwayPlayer.Text, TeamInfor.awayTenDai, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut);
+                        FrmKarismaMenu.FrmSetting.loadTitleScene(cbbAwayPlayer.Text, TeamInfor.awayTenDai, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem);
                     }
                     break;
             }
@@ -679,11 +679,11 @@ namespace VLeague.src.menu
                     }
                     if (!checkPenHome.Checked)
                     {
-                        FrmKarismaMenu.FrmSetting.loadGoalInfo(cbbHomeGoal.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut, GoalTimeHome.Text);
+                        FrmKarismaMenu.FrmSetting.loadGoalInfo(cbbHomeGoal.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem, GoalTimeHome.Text);
                     }
                     else
                     {
-                        FrmKarismaMenu.FrmSetting.loadGoalPenInfo(cbbHomeGoal.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut, GoalTimeHome.Text);
+                        FrmKarismaMenu.FrmSetting.loadGoalPenInfo(cbbHomeGoal.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem, GoalTimeHome.Text);
                     }
                     break;
             }
@@ -718,11 +718,11 @@ namespace VLeague.src.menu
                     }
                     if (checkPenAway.Checked)
                     {
-                        FrmKarismaMenu.FrmSetting.loadGoalPenInfo(cbbAwayGoal.Text, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut, GoalTimeAway.Text);
+                        FrmKarismaMenu.FrmSetting.loadGoalPenInfo(cbbAwayGoal.Text, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem, GoalTimeAway.Text);
                     }
                     else
                     {
-                        FrmKarismaMenu.FrmSetting.loadGoalInfo(cbbAwayGoal.Text, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut, GoalTimeAway.Text);
+                        FrmKarismaMenu.FrmSetting.loadGoalInfo(cbbAwayGoal.Text, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem, GoalTimeAway.Text);
                     }
                     break;
             }
@@ -744,7 +744,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadYellowCard(cbbHomeCard.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+                    FrmKarismaMenu.FrmSetting.loadYellowCard(cbbHomeCard.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
                     break;
             }
         }
@@ -765,7 +765,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadYellowCard(cbbAwayCard.Text, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut);
+                    FrmKarismaMenu.FrmSetting.loadYellowCard(cbbAwayCard.Text, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem);
                     break;
             }
         }
@@ -784,7 +784,7 @@ namespace VLeague.src.menu
             //        FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
             //        break;
             //    case 1:
-            //        FrmKarismaMenu.FrmSetting.loadYellowCard(cbbHomeCard.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+            //        FrmKarismaMenu.FrmSetting.loadYellowCard(cbbHomeCard.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
             //        break;
             //}
         }
@@ -803,7 +803,7 @@ namespace VLeague.src.menu
             //        FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
             //        break;
             //    case 1:
-            //        FrmKarismaMenu.FrmSetting.loadYellowCard(cbbHomeCard.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+            //        FrmKarismaMenu.FrmSetting.loadYellowCard(cbbHomeCard.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
             //        break;
             //}
         }
@@ -824,7 +824,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadTwoYellowCard(cbbHomeCard.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+                    FrmKarismaMenu.FrmSetting.loadTwoYellowCard(cbbHomeCard.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
                     break;
             }
         }
@@ -845,7 +845,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadTwoYellowCard(cbbAwayCard.Text, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut);
+                    FrmKarismaMenu.FrmSetting.loadTwoYellowCard(cbbAwayCard.Text, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem);
                     break;
             }
         }
@@ -866,7 +866,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadRedCard(cbbHomeCard.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+                    FrmKarismaMenu.FrmSetting.loadRedCard(cbbHomeCard.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
                     break;
             }
         }
@@ -887,7 +887,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadRedCard(cbbAwayCard.Text, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut);
+                    FrmKarismaMenu.FrmSetting.loadRedCard(cbbAwayCard.Text, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem);
                     break;
             }
         }
@@ -959,7 +959,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadCoachName(TeamInfor.homeHLV, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+                    FrmKarismaMenu.FrmSetting.loadCoachName(TeamInfor.homeHLV, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
                     break;
             }
         }
@@ -983,7 +983,7 @@ namespace VLeague.src.menu
                     break;
                 case 1:
                     
-                    FrmKarismaMenu.FrmSetting.loadCoachName(TeamInfor.awayHLV, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut);
+                    FrmKarismaMenu.FrmSetting.loadCoachName(TeamInfor.awayHLV, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem);
                     break;
             }
         }
@@ -1011,7 +1011,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadOGInfo(cbbHomeGoal.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut, GoalTimeHome.Text);
+                    FrmKarismaMenu.FrmSetting.loadOGInfo(cbbHomeGoal.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem, GoalTimeHome.Text);
                     if (checkSaveHomeGoal.Checked) // Kiểm tra checkbox trước khi lưu
                     {
                         SaveHomeNameOG();
@@ -1040,7 +1040,7 @@ namespace VLeague.src.menu
                     {
                         SaveAwayNameOG();
                     }
-                    FrmKarismaMenu.FrmSetting.loadOGInfo(cbbAwayGoal.Text, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut, GoalTimeAway.Text);
+                    FrmKarismaMenu.FrmSetting.loadOGInfo(cbbAwayGoal.Text, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem, GoalTimeAway.Text);
                     break;
             }
         }

--- a/src/menu/FrmPostMatch.cs
+++ b/src/menu/FrmPostMatch.cs
@@ -89,7 +89,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerPostMatch);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadAllStatistic(cbbMatch.Text, TeamInfor.homeLogoIn, TeamInfor.awayLogoIn, TeamInfor.homeLogoOut, TeamInfor.awayLogoOut,
+                    FrmKarismaMenu.FrmSetting.loadAllStatistic(cbbMatch.Text, TeamInfor.homeHomeItem, TeamInfor.awayHomeItem, TeamInfor.homeAwayItem, TeamInfor.awayAwayItem,
                         Static.numberHomeScore, Static.numberAwayScore, TeamInfor.homeTenNgan, TeamInfor.awayTenNgan);
                     break;
             }
@@ -113,7 +113,7 @@ namespace VLeague.src.menu
                     break;
                 case 1:
                     string text = $"PENALTY: {Static.numberHomePen} - {Static.numberAwayPen}";
-                    FrmKarismaMenu.FrmSetting.loadAllStatistic(text, TeamInfor.homeLogoIn, TeamInfor.awayLogoIn, TeamInfor.homeLogoOut, TeamInfor.awayLogoOut,
+                    FrmKarismaMenu.FrmSetting.loadAllStatistic(text, TeamInfor.homeHomeItem, TeamInfor.awayHomeItem, TeamInfor.homeAwayItem, TeamInfor.awayAwayItem,
                         Static.numberHomeScore, Static.numberAwayScore, TeamInfor.homeTenNgan, TeamInfor.awayTenNgan);
                     break;
             }

--- a/src/menu/FrmPreMatch.cs
+++ b/src/menu/FrmPreMatch.cs
@@ -118,7 +118,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerPreMatch);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadMatchID(TeamInfor.homeLogoIn, TeamInfor.awayLogoIn, TeamInfor.homeLogoOut, TeamInfor.awayLogoOut, 
+                    FrmKarismaMenu.FrmSetting.loadMatchID(TeamInfor.homeHomeItem, TeamInfor.awayHomeItem, TeamInfor.homeAwayItem, TeamInfor.awayAwayItem, 
                         TeamInfor.homeTenNgan, TeamInfor.awayTenNgan,round, date, location);
                     break;
             }
@@ -224,7 +224,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerPreMatch);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadLineUpSub(TeamInfor.homeTenNgan, TeamInfor.homeHLV, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut, TeamInfor.PlayersHomeLineup, TeamInfor.PlayersHomeSub);
+                    FrmKarismaMenu.FrmSetting.loadLineUpSub(TeamInfor.homeTenNgan, TeamInfor.homeHLV, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem, TeamInfor.PlayersHomeLineup, TeamInfor.PlayersHomeSub);
                     break;
             }           
         }
@@ -259,7 +259,7 @@ namespace VLeague.src.menu
                     GKColor = TeamInfor.GK_HomeColor;
 
                     FrmKarismaMenu.FrmSetting.loadLineUpSubTac(TeamInfor.homePosition , playerColor, GKColor, TeamInfor.homeTenNgan, TeamInfor.homeHLV, TeamInfor.homeTactical, 
-                        TeamInfor.homeLogoIn, TeamInfor.homeLogoOut, TeamInfor.PlayersHomeLineup, TeamInfor.PlayersHomeSub); 
+                        TeamInfor.homeHomeItem, TeamInfor.homeAwayItem, TeamInfor.PlayersHomeLineup, TeamInfor.PlayersHomeSub); 
                     break;
                 case 2:
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerPreMatch);
@@ -284,7 +284,7 @@ namespace VLeague.src.menu
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerPreMatch);
                     break;
                 case 1:
-                    FrmKarismaMenu.FrmSetting.loadLineUpSub(TeamInfor.awayTenNgan, TeamInfor.awayHLV, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut, TeamInfor.PlayersAwayLineup, TeamInfor.PlayersAwaySub);
+                    FrmKarismaMenu.FrmSetting.loadLineUpSub(TeamInfor.awayTenNgan, TeamInfor.awayHLV, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem, TeamInfor.PlayersAwayLineup, TeamInfor.PlayersAwaySub);
                     break;
             }
         }
@@ -323,7 +323,7 @@ namespace VLeague.src.menu
                     GKColor = TeamInfor.GK_AwayColor;
 
                     FrmKarismaMenu.FrmSetting.loadLineUpSubTac(TeamInfor.awayPosition, playerColor, GKColor, TeamInfor.awayTenNgan, TeamInfor.awayHLV, 
-                        TeamInfor.awayTactical, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut, TeamInfor.PlayersAwayLineup, TeamInfor.PlayersAwaySub);
+                        TeamInfor.awayTactical, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem, TeamInfor.PlayersAwayLineup, TeamInfor.PlayersAwaySub);
                     break;
                 case 2:
                     FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerPreMatch);

--- a/src/menu/FrmSetting.cs
+++ b/src/menu/FrmSetting.cs
@@ -320,7 +320,7 @@ namespace VLeague
             process.Start();
         }
         public void loadLineUpSub(string txtTeamLongName,
-    string txtCoachName, string teamLogoIn, string teamLogoOut, Player[] playersLineUp, Player[] PlayersSub)
+    string txtCoachName, string teamHomeItem, string teamAwayItem, Player[] playersLineUp, Player[] PlayersSub)
         {
 
             string scene = "\\teamlineup.t2s";
@@ -353,9 +353,9 @@ namespace VLeague
             }
 
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(teamLogoIn);
+            KAObject.SetValue(teamHomeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(teamLogoOut);
+            KAObject.SetValue(teamAwayItem);
             KAObject = KAScene.GetObject("team");
             KAObject.SetValue(txtTeamLongName);
             KAObject = KAScene.GetObject("hlv");
@@ -367,7 +367,7 @@ namespace VLeague
             KAScenePlayer.Play(layerPreMatch);
         }
         public void loadLineUpSubTac(List<Point> Positions,Color playerColor, Color GKColor, string txtTeamLongName,
-        string txtCoachName, string tactical, string teamLogoIn, string teamLogoOut, Player[] playersLineUp, Player[] PlayersSub)
+        string txtCoachName, string tactical, string teamHomeItem, string teamAwayItem, Player[] playersLineUp, Player[] PlayersSub)
         {
 
             string scene = "\\teamlineup3.t2s";
@@ -414,9 +414,9 @@ namespace VLeague
             KAObject.SetFaceColor(GKColor.R, GKColor.G, GKColor.B, 255);
 
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(teamLogoIn);
+            KAObject.SetValue(teamHomeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(teamLogoOut);
+            KAObject.SetValue(teamAwayItem);
             KAObject = KAScene.GetObject("team");
             KAObject.SetValue(txtTeamLongName);
             KAObject = KAScene.GetObject("hlv");
@@ -438,7 +438,7 @@ namespace VLeague
             KAScenePlayer.Play(layerPreMatch);
         }
 
-        public void loadCoachName(string coachName, string logoIn, string logoOut)
+        public void loadCoachName(string coachName, string homeItem, string awayItem)
         {
             string scene = "\\title.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -451,9 +451,9 @@ namespace VLeague
             KAObject = KAScene.GetObject("title");
             KAObject.SetValue("HUẤN LUYỆN VIÊN TRƯỞNG");
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(logoIn);
+            KAObject.SetValue(homeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(logoOut);
+            KAObject.SetValue(awayItem);
             KAEngine.EndTransaction();
             Thread.Sleep(10);
             KAScenePlayer.Prepare(layerTSL, KAScene);
@@ -480,7 +480,7 @@ namespace VLeague
             Thread.Sleep(10);
             KAScenePlayer.Play(layerTSL);
         }
-        public void loadYellowCard(string playerName, string teamLogoIn, string teamLogoOut)
+        public void loadYellowCard(string playerName, string teamHomeItem, string teamAwayItem)
         {
             string scene = "\\yellowcard.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -491,9 +491,9 @@ namespace VLeague
             KAObject = KAScene.GetObject("name");
             KAObject.SetValue(playerName);
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(teamLogoIn);
+            KAObject.SetValue(teamHomeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(teamLogoOut);
+            KAObject.SetValue(teamAwayItem);
             KAEngine.EndTransaction();
             Thread.Sleep(10);
             KAScenePlayer.Prepare(layerTSL, KAScene);
@@ -520,7 +520,7 @@ namespace VLeague
             Thread.Sleep(10);
             KAScenePlayer.Play(layerTSL);
         }
-        public void loadTwoYellowCard(string playerName, string teamLogoIn, string teamLogoOut)
+        public void loadTwoYellowCard(string playerName, string teamHomeItem, string teamAwayItem)
         {
             string scene = "\\secondyellowcard.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -531,16 +531,16 @@ namespace VLeague
             KAObject = KAScene.GetObject("name");
             KAObject.SetValue(playerName);
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(teamLogoIn);
+            KAObject.SetValue(teamHomeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(teamLogoOut);
+            KAObject.SetValue(teamAwayItem);
             KAEngine.EndTransaction();
             Thread.Sleep(10);
             KAScenePlayer.Prepare(layerTSL, KAScene);
             Thread.Sleep(10);
             KAScenePlayer.Play(layerTSL);
         }
-        public void loadRedCard(string playerName, string teamLogoIn, string teamLogoOut)
+        public void loadRedCard(string playerName, string teamHomeItem, string teamAwayItem)
         {
             string scene = "\\redcard.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -551,9 +551,9 @@ namespace VLeague
             KAObject = KAScene.GetObject("name");
             KAObject.SetValue(playerName);
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(teamLogoIn);
+            KAObject.SetValue(teamHomeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(teamLogoOut);
+            KAObject.SetValue(teamAwayItem);
             KAEngine.EndTransaction();
             Thread.Sleep(10);
             KAScenePlayer.Prepare(layerTSL, KAScene);
@@ -673,7 +673,7 @@ namespace VLeague
             KAScenePlayer.Play(layerTSN);
         }
 
-        public void loadGoalInfo(string playerName, string teamLogoIn, string teamLogoOut, string minutes)
+        public void loadGoalInfo(string playerName, string teamHomeItem, string teamAwayItem, string minutes)
         {
             string scene = "\\ghiban.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -684,9 +684,9 @@ namespace VLeague
             KAObject = KAScene.GetObject("name");
             KAObject.SetValue(playerName + " - " + minutes + "'");
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(teamLogoIn);
+            KAObject.SetValue(teamHomeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(teamLogoOut);
+            KAObject.SetValue(teamAwayItem);
 
             KAEngine.EndTransaction();
             Thread.Sleep(10);
@@ -694,7 +694,7 @@ namespace VLeague
             Thread.Sleep(10);
             KAScenePlayer.Play(layerTSL);
         }
-        public void loadGoalPenInfo(string playerName, string teamLogoIn, string teamLogoOut, string minutes)
+        public void loadGoalPenInfo(string playerName, string teamHomeItem, string teamAwayItem, string minutes)
         {
             string scene = "\\ghiban.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -705,9 +705,9 @@ namespace VLeague
             KAObject = KAScene.GetObject("name");
             KAObject.SetValue(playerName + " - " + minutes + "' (P)");
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(teamLogoIn);
+            KAObject.SetValue(teamHomeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(teamLogoOut);
+            KAObject.SetValue(teamAwayItem);
 
             KAEngine.EndTransaction();
             Thread.Sleep(10);
@@ -715,7 +715,7 @@ namespace VLeague
             Thread.Sleep(10);
             KAScenePlayer.Play(layerTSL);
         }
-        public void loadOGInfo(string playerName, string teamLogoIn, string teamLogoOut, string minutes)
+        public void loadOGInfo(string playerName, string teamHomeItem, string teamAwayItem, string minutes)
         {
             string scene = "\\ghiban.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -726,9 +726,9 @@ namespace VLeague
             KAObject = KAScene.GetObject("name");
             KAObject.SetValue(playerName + " - " + minutes + "' (OG)");
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(teamLogoIn);
+            KAObject.SetValue(teamHomeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(teamLogoOut);
+            KAObject.SetValue(teamAwayItem);
             KAEngine.EndTransaction();
             Thread.Sleep(10);
             KAScenePlayer.Prepare(layerTSL, KAScene);
@@ -736,7 +736,7 @@ namespace VLeague
             KAScenePlayer.Play(layerTSL);
         }
         public void swapOnePlayer(string playerOut,
-    string playerIn, string logoIn, string logoOut)
+    string playerIn, string homeItem, string awayItem)
         {
             string scene = "\\sub1.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -750,16 +750,16 @@ namespace VLeague
             KAObject = KAScene.GetObject("rasan1");
             KAObject.SetValue(playerOut);
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(logoIn);
+            KAObject.SetValue(homeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(logoOut);
+            KAObject.SetValue(awayItem);
             KAEngine.EndTransaction();
             KAScenePlayer.Prepare(layerTSL, KAScene);
             Thread.Sleep(10);
             KAScenePlayer.Play(layerTSL);
         }
         public void swapTwoPlayer(string playerOut, string playerIn, string playerOut2, string playerIn2,
-            string logoIn, string logoOut)
+            string homeItem, string awayItem)
         {
             string scene = "\\sub2.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -777,16 +777,16 @@ namespace VLeague
             KAObject = KAScene.GetObject("rasan2");
             KAObject.SetValue(playerOut2);
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(logoIn);
+            KAObject.SetValue(homeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(logoOut);
+            KAObject.SetValue(awayItem);
             KAEngine.EndTransaction();
             KAScenePlayer.Prepare(layerTSL, KAScene);
             Thread.Sleep(10);
             KAScenePlayer.Play(layerTSL);
         }
         public void swapThreePlayer(string playerOut, string playerIn, string playerOut2, string playerIn2,
-            string playerOut3, string playerIn3, string logoIn, string logoOut)
+            string playerOut3, string playerIn3, string homeItem, string awayItem)
         {
             string scene = "\\sub3.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -808,9 +808,9 @@ namespace VLeague
             KAObject = KAScene.GetObject("rasan3");
             KAObject.SetValue(playerOut3);
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(logoIn);
+            KAObject.SetValue(homeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(logoOut);
+            KAObject.SetValue(awayItem);
             KAEngine.EndTransaction();
             KAScenePlayer.Prepare(layerTSL, KAScene);
             Thread.Sleep(10);
@@ -1189,7 +1189,7 @@ string homeLogo, string awayLogo, string goalhome1, string goalaway1, int startT
             Thread.Sleep(10);
             KAScenePlayer.Play(layerTSL);
         }
-        public void loadTitleScene(string name, string title, string logoIn, string logoOut)
+        public void loadTitleScene(string name, string title, string homeItem, string awayItem)
         {
             string scene = "\\title.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -1202,9 +1202,9 @@ string homeLogo, string awayLogo, string goalhome1, string goalaway1, int startT
             KAObject = KAScene.GetObject("title");
             KAObject.SetValue(title);
             KAObject = KAScene.GetObject("logo");
-            KAObject.SetValue(logoIn);
+            KAObject.SetValue(homeItem);
             KAObject = KAScene.GetObject("logoout");
-            KAObject.SetValue(logoOut);
+            KAObject.SetValue(awayItem);
             KAEngine.EndTransaction();
             Thread.Sleep(10);
             KAScenePlayer.Prepare(layerTSL, KAScene);
@@ -1431,7 +1431,7 @@ string title5, string homeIndex5, string awayIndex5, string homeCode, string awa
             Thread.Sleep(10);
             KAScenePlayer.Play(layerTSL);
         }
-        public void loadAllStatistic(string match, string homeLogoIn, string awayLogoIn, string homeLogoOut, string awayLogoOut, string homeScore,
+        public void loadAllStatistic(string match, string homeHomeItem, string awayHomeItem, string homeAwayItem, string awayAwayItem, string homeScore,
             string awayScore, string homeName, string awayName)
         {
             DBConfig.goGetMatchInfoDetail();
@@ -1462,13 +1462,13 @@ string title5, string homeIndex5, string awayIndex5, string homeCode, string awa
             KAObject = KAScene.GetObject("hiepdau");
             KAObject.SetValue(match);
             KAObject = KAScene.GetObject("logo1");
-            KAObject.SetValue(homeLogoIn);
+            KAObject.SetValue(homeHomeItem);
             KAObject = KAScene.GetObject("logo2");
-            KAObject.SetValue(awayLogoIn);
+            KAObject.SetValue(awayHomeItem);
             KAObject = KAScene.GetObject("logo1out");
-            KAObject.SetValue(homeLogoOut);
+            KAObject.SetValue(homeAwayItem);
             KAObject = KAScene.GetObject("logo2out");
-            KAObject.SetValue(awayLogoOut);
+            KAObject.SetValue(awayAwayItem);
             KAObject = KAScene.GetObject("tiso");
             KAObject.SetValue(homeScore + " - " + awayScore);
             KAObject = KAScene.GetObject("homename");
@@ -1639,7 +1639,7 @@ string title5, string homeIndex5, string awayIndex5, string homeCode, string awa
             KAScenePlayer.Play(layerTSL);
         }
 
-        public void loadMatchID(string homeLogoIn, string awayLogoIn, string homeLogoOut, string awayLogoOut, string homeLongName, string awayLongName,string round, string date, string svd)
+        public void loadMatchID(string homeHomeItem, string awayHomeItem, string homeAwayItem, string awayAwayItem, string homeLongName, string awayLongName,string round, string date, string svd)
         {
             string scene = "\\MATCHID.t2s";
             string workingPath = txtWorkingFolder.Text;
@@ -1648,15 +1648,15 @@ string title5, string homeIndex5, string awayIndex5, string homeCode, string awa
             Thread.Sleep(10);
             KAEngine.BeginTransaction();
             KAObject = KAScene.GetObject("logo1");
-            KAObject.SetValue(homeLogoIn);
+            KAObject.SetValue(homeHomeItem);
             KAObject = KAScene.GetObject("logo1out");
-            KAObject.SetValue(homeLogoOut);
+            KAObject.SetValue(homeAwayItem);
             KAObject = KAScene.GetObject("tendai1");
             KAObject.SetValue(homeLongName);
             KAObject = KAScene.GetObject("logo2");
-            KAObject.SetValue(awayLogoIn);
+            KAObject.SetValue(awayHomeItem);
             KAObject = KAScene.GetObject("logo2out");
-            KAObject.SetValue(awayLogoOut);
+            KAObject.SetValue(awayAwayItem);
             KAObject = KAScene.GetObject("tendai2");
             KAObject.SetValue(awayLongName);
             KAObject = KAScene.GetObject("vongdau");

--- a/src/menu/FrmSubstitution.cs
+++ b/src/menu/FrmSubstitution.cs
@@ -160,7 +160,7 @@ namespace VLeague.src.menu
                         //fillAllcbb();
 
                         FrmKarismaMenu.FrmSetting.swapOnePlayer(cbbHomeLineUp1.Text,
-                        cbbHomeSub1.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+                        cbbHomeSub1.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
                         break;
                     case 2:
                         FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
@@ -203,7 +203,7 @@ namespace VLeague.src.menu
                         //fillAllcbb();
 
                         FrmKarismaMenu.FrmSetting.swapTwoPlayer(cbbHomeLineUp1.Text, cbbHomeSub1.Text, 
-                            cbbHomeLineUp2.Text, cbbHomeSub2.Text, TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+                            cbbHomeLineUp2.Text, cbbHomeSub2.Text, TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
                         break;
                     case 2:
                         FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
@@ -249,7 +249,7 @@ namespace VLeague.src.menu
 
                         FrmKarismaMenu.FrmSetting.swapThreePlayer(cbbHomeLineUp1.Text, cbbHomeSub1.Text, 
                             cbbHomeLineUp2.Text, cbbHomeSub2.Text, cbbHomeLineUp3.Text, cbbHomeSub3.Text, 
-                        TeamInfor.homeLogoIn, TeamInfor.homeLogoOut);
+                        TeamInfor.homeHomeItem, TeamInfor.homeAwayItem);
                         break;
                     case 2:
                         FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
@@ -291,7 +291,7 @@ namespace VLeague.src.menu
                         //fillAllcbb();
 
                         FrmKarismaMenu.FrmSetting.swapOnePlayer(cbbAwayLineUp1.Text,
-                        cbbAwaySub1.Text, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut);
+                        cbbAwaySub1.Text, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem);
                         break;
                     case 2:
                         FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
@@ -334,7 +334,7 @@ namespace VLeague.src.menu
                         //fillAllcbb();
 
                         FrmKarismaMenu.FrmSetting.swapTwoPlayer(cbbAwayLineUp1.Text, cbbAwaySub1.Text,
-                            cbbAwayLineUp2.Text, cbbAwaySub2.Text, TeamInfor.awayLogoIn, TeamInfor.awayLogoOut);
+                            cbbAwayLineUp2.Text, cbbAwaySub2.Text, TeamInfor.awayHomeItem, TeamInfor.awayAwayItem);
                         break;
                     case 2:
                         FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);
@@ -380,7 +380,7 @@ namespace VLeague.src.menu
 
                         FrmKarismaMenu.FrmSetting.swapThreePlayer(cbbAwayLineUp1.Text, cbbAwaySub1.Text,
                             cbbAwayLineUp2.Text, cbbAwaySub2.Text, cbbAwayLineUp3.Text, cbbAwaySub3.Text,
-                            TeamInfor.awayLogoIn, TeamInfor.awayLogoOut);
+                            TeamInfor.awayHomeItem, TeamInfor.awayAwayItem);
                         break;
                     case 2:
                         FrmKarismaMenu.FrmSetting.Resume(FrmSetting.layerTSL);

--- a/src/model/TeamInfor.cs
+++ b/src/model/TeamInfor.cs
@@ -15,8 +15,9 @@ namespace VLeague.src.model
         public static string homeTenNgan { get; set; }
         public static string homeHLV { get; set; }
         public static string homeLogo { get; set; }
-        public static string homeLogoIn { get; set; }
-        public static string homeLogoOut { get; set; }
+        public static string homeHomeItem { get; set; }
+        public static string homeAwayItem { get; set; }
+        public static string homeGoalItem { get; set; }
         public static string homeIconPlayer { get; set; }
         public static string homeIconGK { get; set; }
         public static Color Player_HomeColor { get; set; }
@@ -32,8 +33,9 @@ namespace VLeague.src.model
         public static string awayTenNgan { get; set; }
         public static string awayHLV { get; set; }
         public static string awayLogo { get; set; }
-        public static string awayLogoIn { get; set; }
-        public static string awayLogoOut { get; set; }
+        public static string awayHomeItem { get; set; }
+        public static string awayAwayItem { get; set; }
+        public static string awayGoalItem { get; set; }
         public static string awayIconPlayer { get; set; }
         public static string awayIconGK { get; set; }
         public static Color Player_AwayColor { get; set; }
@@ -49,7 +51,7 @@ namespace VLeague.src.model
         // Phương thức để cập nhật SharedData từ FrmDataImport
         public static void UpdateData(string newhomeCode, string newhomeTactical, string newhomeTenDai, string newhomeTenNgan, string newhomeHLV, string newhomeLogo,
                                                string newawayCode, string newawayTactical, string newawayTenDai, string newawayTenNgan, string newawayHLV, string newawayLogo, Color newHomeColor, Color newAwayColor,
-                                               string newhomeLogoIn, string newhomeLogoOut, string newawayLogoIn, string newawayLogoOut, Color GKHomeColor, Color GKAwayColor)
+                                               string newhomeHomeItem, string newhomeAwayItem, string newawayHomeItem, string newawayAwayItem, string newhomeGoalItem, string newawayGoalItem, Color GKHomeColor, Color GKAwayColor)
         {
             homeCode = newhomeCode;
             homeTactical = newhomeTactical;
@@ -57,8 +59,9 @@ namespace VLeague.src.model
             homeTenNgan = newhomeTenNgan;
             homeHLV = newhomeHLV;
             homeLogo = newhomeLogo;
-            homeLogoIn = newhomeLogoIn;
-            homeLogoOut = newhomeLogoOut;
+            homeHomeItem = newhomeHomeItem;
+            homeAwayItem = newhomeAwayItem;
+            homeGoalItem = newhomeGoalItem;
             Player_HomeColor = newHomeColor;
             GK_HomeColor = GKHomeColor;
 
@@ -68,8 +71,9 @@ namespace VLeague.src.model
             awayTenNgan = newawayTenNgan;
             awayHLV = newawayHLV;
             awayLogo = newawayLogo;
-            awayLogoIn = newawayLogoIn;
-            awayLogoOut = newawayLogoOut;
+            awayHomeItem = newawayHomeItem;
+            awayAwayItem = newawayAwayItem;
+            awayGoalItem = newawayGoalItem;
             Player_AwayColor = newAwayColor;
             GK_AwayColor = GKAwayColor;
 


### PR DESCRIPTION
## Summary
- rename TEAM_ID asset variables from LogoIn/LogoOut to Home/Away item names in the data import flow and TeamInfor store
- update match, substitution, and post-match forms to consume the new TeamInfor home/away item properties
- adjust FrmSetting scene loaders to accept home/away item parameters when rendering team graphics

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d38cb2caa88321a71261bdbcb05c7d